### PR TITLE
Fixes dot product for rectangular matrices

### DIFF
--- a/include/data_structure/ndarray.cpp
+++ b/include/data_structure/ndarray.cpp
@@ -532,11 +532,16 @@ ndarray<T> ndarray<T>::dot(const ndarray<T>& other) {
     }
 
     std::vector<std::vector<T>> A_2d(__shape[0], std::vector<T>(__shape[1]));
-    std::vector<std::vector<T>> B_2d(__shape[0], std::vector<T>(__shape[1]));
+    std::vector<std::vector<T>> B_2d(other.__shape[0], std::vector<T>(other.__shape[1]));
 
     for (size_t i = 0; i < __shape[0]; ++i) {
         for (size_t j = 0; j < __shape[1]; ++j) {
             A_2d[i][j] = __data[calculate_offset(i, j)];
+        }
+    }
+    
+    for (size_t i = 0; i < other.__shape[0]; ++i) {
+        for (size_t j = 0; j < other.__shape[1]; ++j) {
             B_2d[i][j] = other.__data[other.calculate_offset(i, j)];
         }
     }

--- a/test/test_matrix_operations.hpp
+++ b/test/test_matrix_operations.hpp
@@ -42,6 +42,29 @@ TEST(NDArrayDotTest, TwoDimensionalDotTest) {
     }
 }
 
+TEST(NDArrayDotTest, TwoDimensionalRectangularDotTest) {
+    std::vector<size_t> shapeA = {2, 3};
+    std::vector<size_t> shapeB = {3, 2};
+    ndarray<int> arrA(shapeA);
+    ndarray<int> arrB(shapeB);
+
+    std::vector<std::vector<int>> dataA = {{1, 2, 3}, {4, 5, 6}};
+    std::vector<std::vector<int>> dataB = {{7, 8}, {9, 10}, {11, 12}};
+    arrA.assign(dataA);
+    arrB.assign(dataB);
+
+    ndarray<int> result = arrA.dot(arrB);
+
+    std::vector<std::vector<int>> expected = manual_dot(dataA, dataB);
+    std::vector<int> resultData = result.data();
+    size_t index = 0;
+    for (const auto& row : expected) {
+        for (int value : row) {
+            EXPECT_EQ(resultData[index++], value);
+        }
+    }
+}
+
 TEST(NDArrayDotTest, MismatchDimensionTest) {
     std::vector<size_t> shapeA = {2, 3};
     std::vector<size_t> shapeB = {2, 2};


### PR DESCRIPTION
Corrects an issue in the dot product operation where the dimensions and data of the second matrix were not properly utilized, leading to incorrect results when multiplying matrices of different, compatible shapes (e.g., M_x_N and N_x_P).

The logic now correctly initializes and populates the internal representation of the second matrix using its own shape and data.

Adds a new unit test to specifically cover the dot product of two-dimensional rectangular matrices, ensuring the operation works as expected for non-square matrices.